### PR TITLE
this fix when you try to compile with rebar/relx

### DIFF
--- a/src/ex_apns.app.src
+++ b/src/ex_apns.app.src
@@ -1,4 +1,4 @@
-% Copyright (c) 2011, Anthony Ramine <n.oxyde@gmail.com>
+%% Copyright (c) 2011, Anthony Ramine <n.oxyde@gmail.com>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above

--- a/src/ex_apns.app.src
+++ b/src/ex_apns.app.src
@@ -1,4 +1,4 @@
-%% Copyright (c) 2011, Anthony Ramine <n.oxyde@gmail.com>
+% Copyright (c) 2011, Anthony Ramine <n.oxyde@gmail.com>
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -17,6 +17,7 @@
   {description, "An APNS client"},
   {vsn, "1.0.2"},
   {registered, [ex_apns_sup]},
+  {modules, []},
   {applications, [
                   kernel,
                   stdlib,


### PR DESCRIPTION
The explanation, that we need {modules,[]} , even empty.
http://lookonmyworks.co.uk/2014/06/16/application-metadata-file-exists-but-is-malformed/
