### PR TITLE
Update dependency jsx version to 2.6.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -13,4 +13,4 @@
 %% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 {deps, [{jsx, ".*",
-		 {git, "git://github.com/talentdeficit/jsx.git", {tag, "v0.9.0"}}}]}.
+		 {git, "git://github.com/talentdeficit/jsx.git", {tag, "v2.6.2"}}}]}.

--- a/src/ex_apns.erl
+++ b/src/ex_apns.erl
@@ -119,7 +119,7 @@ handle_call(_Request, _From, State) ->
 %% @hidden
 handle_cast({send, Token, Payload}, State) ->
   TokenInt = token_to_integer(Token),
-  PayloadBin = jsx:term_to_json(Payload),
+  PayloadBin = jsx:encode(Payload),
   Packet = [<<0, 32:16, TokenInt:256,
             (iolist_size(PayloadBin)):16>> | PayloadBin],
   send(Packet, State);


### PR DESCRIPTION
This allows using maps in the payload on R17+.
It also fixes a build issue with rebar3 when ex_apns is used as a dependency.
