### PR TITLE
Jsx removed term_to_json and added encode

### DIFF
--- a/src/ex_apns.erl
+++ b/src/ex_apns.erl
@@ -125,7 +125,7 @@ handle_cast({send, Token, Payload}, State) ->
   send(Packet, State);
 handle_cast({send, Token, Payload, Expiry}, State = #state{next = Id}) ->
   TokenInt = token_to_integer(Token),
-  PayloadBin = jsx:term_to_json(Payload),
+  PayloadBin = jsx:encode(Payload),
   Packet = [<<1, Id:32, Expiry:32, 32:16, TokenInt:256,
               (iolist_size(PayloadBin)):16>> | PayloadBin],
   send(Packet, State#state{next = Id + 1});


### PR DESCRIPTION
Line 122 (https://github.com/extend/ex_apns/commit/976c86e1c78e7c56ecd539e39944b57ef182acb2#diff-2fa90b17cf061855c561cc9c2aeb3bb2R122) from src/ex_apns.erl was correctly updated due to change in jsx dependency but line 128 needs an update too.
